### PR TITLE
Added function to import meshes created by 'fmesher' from the xfemm p…

### DIFF
--- a/fineale/meshing/mesh_import/fmesher_mesh_import.m
+++ b/fineale/meshing/mesh_import/fmesher_mesh_import.m
@@ -1,0 +1,73 @@
+function [fens,fes,meshinfo] = fmesher_mesh_import (meshpath)
+% Import mesh created using fmesher from the xfemm package (which is a
+% wrapper for Triangle)
+%
+% Syntax
+% 
+% [fens,gcells,meshinfo] = fmesher_mesh_import (filename, xyzscale, saveReadData)
+%
+% Inputs
+%
+%  meshpath - string representing the path to the mesh files saved on disk.
+%    fmesher saves the mesh in several files, with the same basename. The
+%    path supplied to loadmesh_mfemm is the path to any of these files but
+%    without the extension. For example:
+%
+%    /home/myusername/somedirectoy/meshfile
+%
+%    where the directory /home/myusername/somedirectoy/ contains the files
+%    meshfile.edge, meshfile.ele, and meshfile.node generated using
+%    fmesher.
+%
+% 
+
+    
+    % read in the nodes
+    [fid_node, delobj_node] = safefopen ([meshpath, '.node']);
+    
+    C = textscan (fid_node, '%d\t%d\t%d\t%d', 1, 'CommentStyle', '#');
+    
+    meshinfo.NNodes = C{1};
+    meshinfo.NDimensions = C{2};
+    meshinfo.NAttributes = C{3};
+    meshinfo.HasBoundaryMarkers = C{4} == 1;
+    
+    if meshinfo.HasBoundaryMarkers
+        formatstr = '%d\t%f\t%f\t%d';
+    else
+        formatstr = '%d\t%f\t%f';
+    end
+    
+    C = textscan (fid_node, formatstr, meshinfo.NNodes, 'CollectOutput', true, 'CommentStyle', '#');
+    
+    fens = fenode_set (struct ('id', (1:size(C{2},1))', 'xyz', C{2}));
+    
+    % load the elements
+    [fid_ele, delobj_ele] = safefopen ([meshpath, '.ele']);
+    
+    C = textscan (fid_ele, '%d\t%d\t%d', 1, 'CommentStyle', '#');
+    
+    meshinfo.NElements = C{1};
+    meshinfo.NNodesPerElement = C{2};
+    meshinfo.NElementAttributes = C{3};
+    
+    formatstr = ['%d\t', ...
+                 repmat('%d\t', 1, meshinfo.NNodesPerElement), ...
+                 repmat('%d\t', 1, meshinfo.NElementAttributes)];
+              
+    C = textscan (fid_ele, formatstr, meshinfo.NElements, 'CollectOutput', true, 'CommentStyle', '#');
+    
+    fes = fe_set_T3 ( struct ( 'conn', C{1}(:,2:(1+meshinfo.NNodesPerElement)) + 1, ...
+                               'label', C{1}(:,(1+meshinfo.NNodesPerElement+1):end) ....
+                             )  ...
+                    );
+    
+end
+
+function [fid, delobj] = safefopen (filepath)
+
+    fid = fopen (filepath);
+    
+    delobj = onCleanup (@() fclose (fid));
+
+end


### PR DESCRIPTION
…roject, same format as Shewchuk's 'Triangle' format

This pull request adds a function to import a mesh in the format created by my [xfemm project](http://sourceforge.net/projects/xfemm/). This mesh format is actually the same as produced by Jonathan Shewchuk's [Triangle](https://www.cs.cmu.edu/~quake/triangle.html).

The advantage of this is that my xfemm project had a large set of native matlab/Octave geometry creation functions. As an example, the following script creates a spoked structure with holes, meshes it and imports the mesh into fineale:

```matlab
%% set up some variables describing the spoked structure

nspokes = 5;

Rii = 0.2;
Rio = 0.5;

Roi = 1.8;
Roo = 2;

% describes the spacing of spokes (fraction of max possible size of hole)
Cs = [ 0.45, 0.14 ];


%% create the geometry using the xfemm geometry creation functions
FemmProblem = newproblem_mfemm ('planar');

% inner bore
[FemmProblem, ~, ~, ~] = ... 
    addcircle_mfemm (FemmProblem, 0, 0, Rii);
[FemmProblem, ~] = ...
               addblocklabel_mfemm(FemmProblem, 0, 0, 'BlockType', '<No Mesh>');

% outer surface
[FemmProblem, ~, ~, ~] = ...
    addcircle_mfemm (FemmProblem, 0, 0, Roo);

% holes
maxangle = 2*pi / nspokes;

for holen = 0:nspokes-1
    % make a hole
    BlockProps.BlockType = '<No Mesh>';
    BlockProps.InGroup = holen + 10;
    SegProps.InGroup = BlockProps.InGroup;

    [FemmProblem] = addcurvedtrapezoidregion_mfemm (FemmProblem, ...
                                Rio, ...
                                Roi, ...
                                maxangle * (1 - Cs(1)), ...
                                maxangle * (1 - Cs(2)), ...
                                BlockProps, SegProps);

    FemmProblem = rotategroups_mfemm ( FemmProblem, ...
                                       SegProps.InGroup, ...
                                       holen * 2 * pi / nspokes );

end


[FemmProblem, ~] = ...
               addblocklabel_mfemm(FemmProblem, (Rii+Rio)/2, 0, 'BlockType', 'Steel');

% plot the problem specification
plotfemmproblem (FemmProblem);

% mesh the problem
filename = fmesher (FemmProblem);

% load the mesh into fineale
[fens,fes,meshinfo] = fmesher_mesh_import (filename(1:end-4));

% draw it
figure;
drawmesh ({fens,fes}, 'fes'); view (2)
```
The plots produced by the script (by plotfemmproblem and drawmesh) are shown below:

![spoked_problem](https://cloud.githubusercontent.com/assets/3159692/7956435/cad2b706-09d7-11e5-9068-46de0ec9e531.png)

![spoked_mesh](https://cloud.githubusercontent.com/assets/3159692/7956439/d010627c-09d7-11e5-99de-be8bc1f64ac6.png)

